### PR TITLE
Allow all using "*" in port, volume, cap, device, dns, logdriver, log…

### DIFF
--- a/docker/allow/container.go
+++ b/docker/allow/container.go
@@ -93,7 +93,7 @@ func AllowContainerCreate(req authorization.Request, config *types.Config) *type
 		}
 	}
 
-	if len(cc.HostConfig.CapAdd) > 0 {
+	if len(cc.HostConfig.CapAdd) > 0 && !p.Validate(config.Username, "cap", "*", "") {
 		for _, c := range cc.HostConfig.CapAdd {
 			if !p.Validate(config.Username, "cap", c, "") {
 				return &types.AllowResult{Allow: false, Msg: fmt.Sprintf("Capability %s is not allowed", c)}
@@ -101,7 +101,7 @@ func AllowContainerCreate(req authorization.Request, config *types.Config) *type
 		}
 	}
 
-	if len(cc.HostConfig.Devices) > 0 {
+	if len(cc.HostConfig.Devices) > 0 && !p.Validate(config.Username, "device", "*", "") {
 		for _, dev := range cc.HostConfig.Devices {
 			if !p.Validate(config.Username, "device", dev.PathOnHost, "") {
 				return &types.AllowResult{Allow: false, Msg: fmt.Sprintf("Device %s is not allowed to be exported", dev.PathOnHost)}
@@ -109,7 +109,7 @@ func AllowContainerCreate(req authorization.Request, config *types.Config) *type
 		}
 	}
 
-	if len(cc.HostConfig.DNS) > 0 {
+	if len(cc.HostConfig.DNS) > 0 && !p.Validate(config.Username, "dns", "*", "") {
 		for _, dns := range cc.HostConfig.DNS {
 			if !p.Validate(config.Username, "dns", dns, "") {
 				return &types.AllowResult{Allow: false, Msg: fmt.Sprintf("DNS server %s is not allowed", dns)}
@@ -123,7 +123,7 @@ func AllowContainerCreate(req authorization.Request, config *types.Config) *type
 		}
 	}
 
-	if len(cc.HostConfig.PortBindings) > 0 {
+	if len(cc.HostConfig.PortBindings) > 0 && !p.Validate(config.Username, "port", "*", "") {
 		for _, pbs := range cc.HostConfig.PortBindings {
 			for _, pb := range pbs {
 				spb := GetPortBindingString(&pb)
@@ -135,7 +135,7 @@ func AllowContainerCreate(req authorization.Request, config *types.Config) *type
 		}
 	}
 
-	if len(cc.HostConfig.Binds) > 0 {
+	if len(cc.HostConfig.Binds) > 0 && !p.Validate(config.Username, "volume", "*", "") {
 		p.End()
 
 		for _, b := range cc.HostConfig.Binds {
@@ -147,13 +147,13 @@ func AllowContainerCreate(req authorization.Request, config *types.Config) *type
 		}
 	}
 
-	if len(cc.HostConfig.LogConfig.Type) > 0 {
+	if len(cc.HostConfig.LogConfig.Type) > 0 && !p.Validate(config.Username, "logdriver", "*", "") {
 		if !p.Validate(config.Username, "logdriver", cc.HostConfig.LogConfig.Type, "") {
 			return &types.AllowResult{Allow: false, Msg: fmt.Sprintf("Log driver %s is not allowed", cc.HostConfig.LogConfig.Type)}
 		}
 	}
 
-	if len(cc.HostConfig.LogConfig.Config) > 0 {
+	if len(cc.HostConfig.LogConfig.Config) > 0 && !p.Validate(config.Username, "logopt", "*", "") {
 		for k, v := range cc.HostConfig.LogConfig.Config {
 			los := fmt.Sprintf("%s=%s", k, v)
 

--- a/docker/resource/driver/capability/capability.go
+++ b/docker/resource/driver/capability/capability.go
@@ -64,6 +64,10 @@ func (c *Config) List() interface{} {
 }
 
 func (c *Config) Valid(value string) error {
+	if value == "*" {
+		return nil
+	}
+
 	for _, capability := range c.Capabilities {
 		if capability == value {
 			return nil

--- a/docker/resource/driver/logdriver/logdriver.go
+++ b/docker/resource/driver/logdriver/logdriver.go
@@ -37,6 +37,10 @@ func (c *Config) List() interface{} {
 }
 
 func (c *Config) Valid(value string) error {
+	if value == "*" {
+		return nil
+	}
+
 	for _, logdriver := range c.Drivers {
 		if logdriver == value {
 			return nil

--- a/docker/resource/driver/port/port.go
+++ b/docker/resource/driver/port/port.go
@@ -1,7 +1,6 @@
 package port
 
 import (
-	"fmt"
 	"strconv"
 
 	"github.com/juliengk/go-utils/validation"
@@ -25,6 +24,10 @@ func (c *Config) List() interface{} {
 }
 
 func (c *Config) Valid(value string) error {
+	if value == "*" {
+		return nil
+	}
+
 	port, err := strconv.Atoi(value)
 	if err != nil {
 		return err

--- a/packages.go
+++ b/packages.go
@@ -12,6 +12,7 @@ import (
 	_ "github.com/kassisol/hbm/docker/resource/driver/image"
 	_ "github.com/kassisol/hbm/docker/resource/driver/logdriver"
 	_ "github.com/kassisol/hbm/docker/resource/driver/logopt"
+	_ "github.com/kassisol/hbm/docker/resource/driver/port"
 	_ "github.com/kassisol/hbm/docker/resource/driver/registry"
 	_ "github.com/kassisol/hbm/docker/resource/driver/volume"
 )


### PR DESCRIPTION
I implemented a feature that allows all in port, volume, cap, device, dns, logdriver, logopt.
By default, above of them are denied to all and there is no way to allow all.

Now an user can allow all using "*".

In this job, I found `port` is missing in packages.go and so it is not loaded, which makes `port` unconfigurable.

Please check my PR and give me suggestion.
Thanks!