### PR TITLE
User "all" is also valid for ports

### DIFF
--- a/object/policy/policy.go
+++ b/object/policy/policy.go
@@ -178,7 +178,7 @@ func (c *Config) Validate(user, rType, rValue, rOptions string) bool {
 	}
 
 	if rType == "port" {
-		return c.allowPort(user, rValue)
+		return c.allowPort(user, rValue) || c.allowPort("all", rValue)
 	}
 
 	return false


### PR DESCRIPTION
In the admin guide, there is a table that explains how to use the keyword `all` for users and resources type or value.

User | Resource Type | Resource Value | Resource Options
-- | -- | -- | --
all | all | all | all
all | all | all | \<empty>
all | \<rType> | all | all
all | \<rType> | all | \<empty>
all | \<rType> | \<rValue> | \<rOptions>
\<user> | \<rType> | all | all
\<user> | \<rType> | all | \<empty>
\<user> | \<rType> | \<rValue> | \<rOptions>

According to this table, next entry should work:

User | Resource Type | Resource Value | Resource Options
-- | -- | -- | --
all | port | 8000-8080 | \<empty>

But it does not. It works only when `<user>` is specified. This pull request fixes this behavior.
