### PR TITLE
Assert *cc.HostConfig.OomKillDisable == nil

### DIFF
--- a/docker/allow/container.go
+++ b/docker/allow/container.go
@@ -325,7 +325,7 @@ func ContainerCreate(req authorization.Request, config *types.Config) *types.All
 		}
 	}
 
-	if *cc.HostConfig.OomKillDisable {
+	if cc.HostConfig.OomKillDisable != nil && *cc.HostConfig.OomKillDisable {
 		if !p.Validate(config.Username, "config", "container_create_param_oom_kill_disable", "") {
 			return &types.AllowResult{
 				Allow: false,


### PR DESCRIPTION
Using docker-compose, *cc.HostConfig.OomKillDisable is set to nil.
If merged, please update `HBM` including this commit.